### PR TITLE
publish testkit to help users of scala-aws-utils mock their dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
       scala: 2.12.1
       condition: $(git log -n1 --format=format:"%an") != "Dwolla Bot"
   - provider: script
-    script: sbt ++$TRAVIS_SCALA_VERSION publish
+    script: sbt ++$TRAVIS_SCALA_VERSION publish testkit/publish
     on:
       tags: true
       condition: $(git log -n1 --format=format:"%an") == "Dwolla Bot"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,41 @@
 Utilities package for working with the Java AWS SDKs from Scala and SBT.
 
 Projects including this library will also need to explicitly include the AWS SDK libraries they will rely on, to avoid inadvertently importing more libraries than are required.
+
+## Artifacts
+
+#### Library
+
+```scala
+"com.dwolla" %% "scala-aws-utils" % "1.4.0"
+```
+
+#### Test Kit
+
+```scala
+"com.dwolla" %% "scala-aws-utils-testkit" % "1.4.0" % Test
+```
+
+The test kit provides helpers to make mocking the Amazon Async Clients easier. The clients have interfaces like
+
+```java
+java.util.concurrent.Future<DescribeInstancesResult> describeInstancesAsync(DescribeInstancesRequest describeInstancesRequest,
+                                                                            AsyncHandler<DescribeInstancesRequest, DescribeInstancesResult> asyncHandler)
+```
+
+Because the method returns a Java `Future`, the “return value” for the function is actually returned by invoking a method on the passed `AsyncHandler`. This is inconvenient to set up.
+
+Instead, the test kit provides a DSL for setting up the mocks. For example:
+
+```scala
+import com.dwolla.awssdk.AmazonAsyncMockingImplicits._
+
+val mockClient = mock[AmazonEC2Async]
+
+mockedMethod(mockClient.describeInstancesAsync) answers (
+  new DescribeInstancesRequest().withInstanceIds("i-instance") → new DescribeInstancesResult(),
+  new DescribeInstancesRequest() → new AmazonServiceException("access denied exception intentionally thrown by test")
+)
+```
+
+The mocked method is provided with a mapping of `AmazonWebServiceRequest` instances of the correct type to the expected results. The results can either be actual result instances or exceptions to be thrown.

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
-lazy val buildSettings = Seq(
+lazy val primaryName = "scala-aws-utils"
+lazy val specs2Version = "3.8.6"
+
+lazy val commonSettings = Seq(
   organization := "com.dwolla",
-  name := "scala-aws-utils",
   homepage := Some(url("https://github.com/Dwolla/scala-aws-utils")),
-  description := "Utilities for interacting with the AWS SDKs from Scala",
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
   releaseVersionBump := sbtrelease.Version.Bump.Minor,
   releaseProcess := {
@@ -23,7 +24,6 @@ lazy val buildSettings = Seq(
   startYear := Option(2016),
   libraryDependencies ++= {
     val awsSdkVersion = "1.11.113"
-    val specs2Version = "3.8.6"
     Seq(
       "com.amazonaws"   %  "aws-java-sdk-core"            % awsSdkVersion,
       "com.amazonaws"   %  "aws-java-sdk-cloudformation"  % awsSdkVersion % Provided,
@@ -37,6 +37,7 @@ lazy val buildSettings = Seq(
 )
 
 lazy val bintraySettings = Seq(
+  bintrayPackage := primaryName,
   bintrayVcsUrl := homepage.value.map(_.toString),
   publishMavenStyle := false,
   bintrayRepository := "maven",
@@ -45,4 +46,21 @@ lazy val bintraySettings = Seq(
 )
 
 lazy val scalaAwsUtils = (project in file("."))
-  .settings(buildSettings ++ bintraySettings: _*)
+  .settings({
+    Seq(
+      name := primaryName,
+      description := "Utilities for interacting with the AWS SDKs from Scala"
+    )
+  } ++ commonSettings ++ bintraySettings: _*)
+  .dependsOn(testkit)
+
+lazy val testkit = (project in file("testkit"))
+  .settings(Seq(
+    name := primaryName + "-testkit",
+    description := "Test utilities for interacting with the AWS SDKs from Scala",
+    libraryDependencies ++= {
+      Seq(
+        "org.specs2"      %% "specs2-mock"                  % specs2Version
+      )
+    }
+  ) ++ commonSettings ++ bintraySettings: _*)

--- a/src/test/scala/com/dwolla/awssdk/cloudformation/CloudFormationClientSpec.scala
+++ b/src/test/scala/com/dwolla/awssdk/cloudformation/CloudFormationClientSpec.scala
@@ -1,18 +1,14 @@
 package com.dwolla.awssdk.cloudformation
 
-import java.util.concurrent.{Future ⇒ JFuture}
-
-import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.cloudformation.model.StackStatus.UPDATE_COMPLETE
 import com.amazonaws.services.cloudformation.model._
+import com.dwolla.awssdk.AmazonAsyncMockingImplicits._
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import CloudFormationAsyncMethodImplicits._
-import scala.reflect.ClassTag
 
 //noinspection RedundantDefaultArgument
 class CloudFormationClientSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
@@ -86,24 +82,6 @@ class CloudFormationClientSpec(implicit ee: ExecutionEnv) extends Specification 
       requestCaptor.value must beLike { case req ⇒
         req.getChangeSetName must_== "change-set-name"
         req.getChangeSetType must_== "CREATE"
-      }
-    }
-  }
-
-}
-
-object CloudFormationAsyncMethodImplicits {
-  implicit class CloudFormationAsyncResult[Res](res: Res) {
-    import org.specs2.mock.mockito.MockitoMatchers._
-    import org.specs2.mock.mockito.MockitoStubs._
-
-    def completes[Req <: AmazonWebServiceRequest : ClassTag](func: (Req, AsyncHandler[Req, Res]) ⇒ JFuture[Res]): Unit = {
-      func(any[Req], any[AsyncHandler[Req, Res]]) answers { args ⇒
-        args match {
-          case Array(req: Req, handler: AsyncHandler[Req, Res]) ⇒
-            handler.onSuccess(req, res)
-        }
-        null
       }
     }
   }

--- a/testkit/src/main/scala/com/dwolla/awssdk/AmazonAsyncMockingImplicits.scala
+++ b/testkit/src/main/scala/com/dwolla/awssdk/AmazonAsyncMockingImplicits.scala
@@ -1,0 +1,97 @@
+package com.dwolla.awssdk
+
+import java.util.concurrent.{Future ⇒ JFuture}
+
+import com.amazonaws.AmazonWebServiceRequest
+import com.amazonaws.handlers.AsyncHandler
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+object AmazonAsyncMockingImplicits {
+
+  /**
+    * For example:
+    *
+    * {{{
+    *   import com.dwolla.awssdk.AmazonMockAsyncImplicits._
+    *   import com.amazonaws.services.cloudformation.model.{UpdateStackRequest, UpdateStackResult}
+    *
+    *   mockedMethod(mock[AmazonCloudFormationAsync].updateStackAsync) answers(
+    *     new UpdateStackRequest() → new UpdateStackResult(),
+    *     new UpdateStackRequest().withStackName("bad-name") → new RuntimeException("bad stack name!")
+    *   )
+    * }}}
+    *
+    * @param func the Amazon async client method to be mocked
+    * @tparam Req an Amazon web service request object
+    * @tparam Res an Amazon web service result object
+    * @return MockAnswerMappingBuilder
+    */
+  def mockedMethod[Req <: AmazonWebServiceRequest : ClassTag, Res](func: (Req, AsyncHandler[Req, Res]) ⇒ JFuture[Res]): MockAnswerMappingBuilder[Req, Res] = new MockAnswerMappingBuilder(func)
+
+  /**
+    * For example:
+    *
+    * {{{
+    *   import com.dwolla.awssdk.AmazonMockAsyncImplicits._
+    *   new UpdateStackResult() completes mock[AmazonCloudFormationAsync].updateStackAsync
+    * }}}
+    *
+    */
+  implicit class AmazonAsyncResult[Res](res: Res) {
+    import org.specs2.mock.mockito.MockitoMatchers._
+    import org.specs2.mock.mockito.MockitoStubs._
+
+    def completes[Req <: AmazonWebServiceRequest : ClassTag](func: (Req, AsyncHandler[Req, Res]) ⇒ JFuture[Res]): Unit = {
+      func(any[Req], any[AsyncHandler[Req, Res]]) answers { args ⇒
+        args match {
+          case Array(req: Req, handler: AsyncHandler[Req, Res]) ⇒ handler.onSuccess(req, res)
+        }
+        null
+      }
+    }
+  }
+
+  /**
+    * For example:
+    *
+    * {{{
+    *   import com.dwolla.awssdk.AmazonMockAsyncImplicits._
+    *   import com.amazonaws.services.ecs.AmazonECSAsync
+    *   import com.amazonaws.services.ecs.model.{Cluster, DescribeClustersResult, ListContainerInstancesRequest, ListContainerInstancesResult}
+    *
+    *   Map(
+    *     new ListContainerInstancesRequest().withCluster("cluster1") → new ListContainerInstancesResult().withContainerInstanceArns("arn1").withNextToken("next-token"),
+    *     new ListContainerInstancesRequest().withCluster("cluster1").withNextToken("next-token") → new ListContainerInstancesResult().withContainerInstanceArns("arn2")
+    *   ) completes mock[AmazonECSAsync].listContainerInstancesAsync
+    * }}}
+    */
+  implicit class AmazonAsyncResults[Req <: AmazonWebServiceRequest : ClassTag, Res](responseMapping: Map[Req, Either[Exception, Res]]) {
+
+    import org.specs2.mock.mockito.MockitoMatchers._
+    import org.specs2.mock.mockito.MockitoStubs._
+
+    def completes(func: (Req, AsyncHandler[Req, Res]) ⇒ JFuture[Res]): Unit = {
+      func(any[Req], any[AsyncHandler[Req, Res]]) answers { args ⇒
+        args match {
+          case Array(req: Req, _) if !responseMapping.contains(req) ⇒ throw TestSetupException(s"req/res mapping does not contain `$req`. Look at the mock setup: is an expected case missing?")
+          case Array(req: Req, handler: AsyncHandler[Req, Res]) ⇒ responseMapping(req) match {
+            case Left(ex) ⇒ handler.onError(ex)
+            case Right(res) ⇒ handler.onSuccess(req, res)
+          }
+        }
+        null
+      }
+    }
+
+    case class TestSetupException(msg: String) extends RuntimeException(msg)
+  }
+
+  class MockAnswerMappingBuilder[Req <: AmazonWebServiceRequest : ClassTag, Res](func: (Req, AsyncHandler[Req, Res]) ⇒ JFuture[Res]) {
+    def answers(requestResponseMappings: (Req, Either[Exception, Res])*): Unit = Map(requestResponseMappings: _*) completes func
+  }
+
+  implicit def liftExceptionToLeft[Res](ex: Exception): Either[Exception, Res] = Left(ex)
+  implicit def liftResponseToRight[Res](res: Res): Either[Exception, Res] = Right(res)
+}


### PR DESCRIPTION
I want to use the implicit class in `AmazonAsyncMockingImplicits` in another project, for the same reason it was already being used in `CloudFormationClientSpec`.