### PR TITLE
remove specs2 as a dependency of the testkit project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: scala
 
 scala:
-  - 2.10.6
-  - 2.11.8
-  - 2.12.1
+  - 2.10.7
+  - 2.11.12
+  - 2.12.4
 
 env:
   global:
@@ -15,11 +15,11 @@ env:
 matrix:
   # scala 2.12 requires java 8
   exclude:
-    - scala: 2.12.1
+    - scala: 2.12.4
       env: JDK=oraclejdk7
-    - scala: 2.11.8
+    - scala: 2.11.12
       env: JDK=oraclejdk8
-    - scala: 2.10.6
+    - scala: 2.10.7
       env: JDK=oraclejdk8
 
 before_script:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 lazy val primaryName = "scala-aws-utils"
-lazy val specs2Version = "3.8.9"
 
 lazy val commonSettings = Seq(
   organization := "com.dwolla",
@@ -19,11 +18,13 @@ lazy val commonSettings = Seq(
       pushChanges
     )
   },
-  scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1"),
+  scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.4"),
   startYear := Option(2016),
   libraryDependencies ++= {
     val awsSdkVersion = "1.11.136"
+    val specs2Version = "3.8.9"
+
     Seq(
       "com.amazonaws"   %  "aws-java-sdk-core"            % awsSdkVersion,
       "com.amazonaws"   %  "aws-java-sdk-cloudformation"  % awsSdkVersion % Provided,
@@ -61,7 +62,7 @@ lazy val testkit = (project in file("testkit"))
     description := "Test utilities for interacting with the AWS SDKs from Scala",
     libraryDependencies ++= {
       Seq(
-        "org.specs2"      %% "specs2-mock"                  % specs2Version
+        "org.mockito"   %  "mockito-core"                % "1.9.5"
       )
     }
   ) ++ commonSettings ++ bintraySettings: _*)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")


### PR DESCRIPTION
This should let us pull the testkit into a scalatest project using mockito and not have multiple test frameworks in scope.